### PR TITLE
スマホで見たときに画面いっぱいに表示されるように修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="kansou.css">
   <title>感想自動作成フォーム</title>
 </head>

--- a/kansou.css
+++ b/kansou.css
@@ -1,7 +1,8 @@
 body {
     background-color: #3399FF;
     color: #FDFFFF;
-    width: 500px;
+    width: 98vw;
+    max-width: 500px;
     margin-right: auto;
     margin-left : auto;
   }


### PR DESCRIPTION
### 素晴らしい同人活動のために支援です

![コメント 2020-07-06 220325](https://user-images.githubusercontent.com/34544233/86596011-885d2880-bfd4-11ea-8b04-c312dcb9175b.jpg)
修正前

![コメント 2020-07-06 220253](https://user-images.githubusercontent.com/34544233/86596019-8b581900-bfd4-11ea-8e87-04d83bc9a39d.jpg)
修正後

スマホから見ても見やすいように修正しました

**追記部分**
`<meta name="viewport" content="width=device-width,initial-scale=1">`
いい感じに表示するためのおまじないだとお考え下さい

```
width: 98vw;
max-width: 500px;
```
コンテンツの横幅を「画面サイズ横幅の98%」に指定(スマホでも画面いっぱいに表示されます)
コンテンツの横幅の最大値を「500px」に指定(PCで見ても500px以上大きくならないようにすることで中央に表示)

github pagesのホスティングがどのブランチになっているか分かりませんがとりあえずgh-pagesにプルリクしておきます。
masterブランチをホスティングしている場合はgh-pagesをmasterにマージしていただくとgithub pagesでも表示されるかと思います。